### PR TITLE
fix ship-connection, sync-up from the genesis then stay up to date

### DIFF
--- a/cmd/ship_receiver_plugin.cpp
+++ b/cmd/ship_receiver_plugin.cpp
@@ -213,7 +213,7 @@ class ship_receiver_plugin_impl : std::enable_shared_from_this<ship_receiver_plu
                eosio::ship_protocol::transaction_trace tt;
                try {
                   tt = eosio::from_bin<eosio::ship_protocol::transaction_trace>(*block.traces);
-               } catch (std::exception e) {
+               } catch (const std::exception &e) {
                   SILK_ERROR << "failed to decode transaction_trace trace data remaining = " << block.traces->remaining() << ", " << e.what();
                   throw;
                }
@@ -239,14 +239,14 @@ class ship_receiver_plugin_impl : std::enable_shared_from_this<ship_receiver_plu
          return current_block.building ? std::optional<native_block_t>(std::move(current_block)) : std::nullopt;
       }
 
-      template <typename BlockResult>
-      inline native_block_t start_native_block(BlockResult&& res) const {
+      inline native_block_t start_native_block(eosio::ship_protocol::get_blocks_result_v0& res) const {
+         SILK_INFO << "start native block " << res.this_block->block_num; 
          native_block_t block;
          block.block_num = res.this_block->block_num;
-         eosio::ship_protocol::signed_block_v1 sb;
+         eosio::ship_protocol::signed_block_v0 sb;
          eosio::from_bin(sb, *res.block);
          block.timestamp = sb.timestamp.to_time_point().time_since_epoch().count();
-         SILK_INFO << "Started native block " << block.block_num;
+         SILK_DEBUG << "Leave native block " << block.block_num;
          return block;
       }
 


### PR DESCRIPTION
TrustEVM node should start syncing from genesis and stay in-sync with nodeos (receving each block at every 0.5s) , for example:

```
  INFO [09-23|10:12:36.203 UTC] Started Engine Server
  INFO [09-23|10:12:36.203 UTC] Started SHiP Receiver
  INFO [09-23|10:12:36.204 UTC] Syncing from block #2 and stay up to date
 DEBUG [09-23|10:12:36.205 UTC] on_block_result #2, received_blocks 1
 DEBUG [09-23|10:12:36.205 UTC] act onblock receiver eosio
 DEBUG [09-23|10:12:36.205 UTC] on_block_result #3, received_blocks 2
 DEBUG [09-23|10:12:36.205 UTC] act onblock receiver eosio
 DEBUG [09-23|10:12:36.205 UTC] on_block_result #4, received_blocks 3
 DEBUG [09-23|10:12:36.205 UTC] act onblock receiver eosio
 DEBUG [09-23|10:12:36.401 UTC] on_block_result #5, received_blocks 4
 DEBUG [09-23|10:12:36.401 UTC] act onblock receiver eosio
 DEBUG [09-23|10:12:36.900 UTC] on_block_result #6, received_blocks 5
 DEBUG [09-23|10:12:36.900 UTC] act onblock receiver eosio
 DEBUG [09-23|10:12:37.401 UTC] on_block_result #7, received_blocks 6
 DEBUG [09-23|10:12:37.401 UTC] act onblock receiver eosio
 DEBUG [09-23|10:12:37.900 UTC] on_block_result #8, received_blocks 7
 DEBUG [09-23|10:12:37.900 UTC] act onblock receiver eosio
 DEBUG [09-23|10:12:38.400 UTC] on_block_result #9, received_blocks 8
 DEBUG [09-23|10:12:38.400 UTC] act onblock receiver eosio
 DEBUG [09-23|10:12:38.900 UTC] on_block_result #10, received_blocks 9
 DEBUG [09-23|10:12:38.900 UTC] act onblock receiver eosio
 DEBUG [09-23|10:12:39.400 UTC] on_block_result #11, received_blocks 10
```

also the following diff need to be applied to fix SHIP communication:
```
kayan-u20@kayan-u20:~/workspaces/TrustEVM/external/mandel-abieos$ git diff
diff --git a/include/eosio/ship_protocol.hpp b/include/eosio/ship_protocol.hpp
index 98ad722..c333d12 100644
--- a/include/eosio/ship_protocol.hpp
+++ b/include/eosio/ship_protocol.hpp
@@ -251,14 +251,14 @@ namespace eosio { namespace ship_protocol {
       int64_t                       elapsed                = {};
       std::string                   console                = {};
       std::vector<account_delta>    account_ram_deltas     = {};
-      std::vector<account_delta>    account_disk_deltas    = {};
+      //std::vector<account_delta>    account_disk_deltas    = {}; // Does this break old data??
       std::optional<std::string>    except                 = {};
       std::optional<uint64_t>       error_code             = {};
       eosio::input_stream           return_value           = {};
    };
 
    EOSIO_REFLECT(action_trace_v1, action_ordinal, creator_action_ordinal, receipt, receiver, act, context_free, elapsed,
-                 console, account_ram_deltas, account_disk_deltas, except, error_code, return_value)
+                 console, account_ram_deltas, except, error_code, return_value)
 
    using action_trace = std::variant<action_trace_v0, action_trace_v1>;
 ```
