### PR TITLE
make eosio action return data contains return value of eth contract execution

### DIFF
--- a/contract/include/evm_runtime/evm_contract.hpp
+++ b/contract/include/evm_runtime/evm_contract.hpp
@@ -11,17 +11,25 @@ using namespace eosio;
 
 namespace evm_runtime {
 
+using namespace silkworm;
+
+struct push_tx_result {
+      db_stats        stats;
+      uint64_t        gas_left{0};
+      bytes           return_data;
+};
+
 CONTRACT evm_contract : public contract {
    public:
       using contract::contract;
 
       [[eosio::action]]
-      db_stats pushtx(eosio::name ram_payer, const bytes& rlptx);
+      push_tx_result pushtx(eosio::name ram_payer, const bytes& rlptx);
 
 #ifdef WITH_TEST_ACTIONS
       ACTION testtx( const bytes& rlptx, const evm_runtime::test::block_info& bi );
       ACTION updatecode( const bytes& address, uint64_t incarnation, const bytes& code_hash, const bytes& code);
-      ACTION updateaccnt(const bytes& address, const bytes& initial, const bytes& current);
+    //  ACTION updateaccnt(const bytes& address, const bytes& initial, const bytes& current);
       ACTION updatestore(const bytes& address, uint64_t incarnation, const bytes& location, const bytes& initial, const bytes& current);
       ACTION dumpstorage(const bytes& addy);
       ACTION clearall();

--- a/contract/include/evm_runtime/processor.hpp
+++ b/contract/include/evm_runtime/processor.hpp
@@ -47,7 +47,7 @@ class ExecutionProcessor {
 
     // Execute a transaction, but do not write to the DB yet.
     // Precondition: transaction must be valid.
-    void execute_transaction(const Transaction& txn, Receipt& receipt) noexcept;
+    CallResult execute_transaction(const Transaction& txn, Receipt& receipt) noexcept;
 
     uint64_t cumulative_gas_used() const noexcept { return cumulative_gas_used_; }
 


### PR DESCRIPTION
This PR will expose the return value of eth action, as well as the gas left number into the eosio action return data, so that you can in thoery execute any view actions and get back the result via nodeos.

For example. 

solidity contract:
```
// SPDX-License-Identifier: GPL-3.0

pragma solidity >=0.7.0 <0.9.0;

/**
 * @title Storage
 * @dev Store & retrieve value in a variable
 * @custom:dev-run-script ./scripts/deploy_with_ethers.ts
 */
contract Storage {

    uint256 number;

    /**
     * @dev Store value in variable
     * @param num value to store
     */
    function store(uint256 num) public {
        number = num;
    }

    /**
     * @dev Return value 
     * @return value of 'number'
     */
    function retrieve() public view returns (uint256){
        return number;
    }
}
```

execute the "store" function(hash 6057361d) with num=0x7d, 
```
python3 ./send_data_via_cleos.py 2787b98fc4e731d0456b3941f0b3fe2e01439961 2787b98fc4e731d0456b3941f0b3fe2e01430000 0 6057361d000000000000000000000000000000000000000000000000000000000000007d 6
```
result:
```
        "return_value_hex_data": "0600000002000000000000000000000002000000010000000000000000000000a01e01000000000000",
        "return_value_data": {
          "stats": {
            "account": {
              "read": 6,
              "update": 2,
              "create": 0,
              "remove": 0
            },
            "storage": {
              "read": 2,
              "update": 1,
              "create": 0,
              "remove": 0
            }
          },
          "gas_left": 73376,
          "return_data": ""
        }
```


execute the view function "retrieve" (hash 2e64cec1)
```
python3 ./send_data_via_cleos.py 2787b98fc4e731d0456b3941f0b3fe2e01439961 2787b98fc4e731d0456b3941f0b3fe2e01430000 0 2e64cec1 7
```
result:
```
        "return_value_hex_data": "0600000002000000000000000000000002000000010000000000000000000000fd2f01000000000020000000000000000000000000000000000000000000000000000000000000007d",
        "return_value_data": {
          "stats": {
            "account": {
              "read": 6,
              "update": 2,
              "create": 0,
              "remove": 0
            },
            "storage": {
              "read": 2,
              "update": 1,
              "create": 0,
              "remove": 0
            }
          },
          "gas_left": 77821,
          "return_data": "000000000000000000000000000000000000000000000000000000000000007d"
        }
```
notice that the return data is the hex bytes of a uint256


