### PR TITLE
idempotent token distribution script

### DIFF
--- a/peripherals/token_distribution/distribute_to_accounts.py
+++ b/peripherals/token_distribution/distribute_to_accounts.py
@@ -1,0 +1,122 @@
+import os
+import sys
+from datetime import datetime, timedelta
+from getpass import getpass
+from binascii import hexlify
+from ethereum.utils import privtoaddr, encode_hex, decode_hex, bytes_to_int
+from ethereum import transactions
+from binascii import unhexlify
+import time
+import subprocess
+import requests
+import rlp
+import json
+import csv
+
+EVM_CONTRACT    = os.getenv("EVM_CONTRACT", "evmevmevmevm")
+NODEOS_ENDPOINT = os.getenv("NODEOS_ENDPOINT", "http://127.0.0.1:8888")
+EOS_SENDER      = os.getenv("EOS_SENDER", "evmevmevmevm")
+EVM_SENDER_KEY  = os.getenv("EVM_SENDER_KEY", None)
+EOS_SENDER_KEY  = os.getenv("EOS_SENDER_KEY", None)
+EVM_CHAINID     = int(os.getenv("EVM_CHAINID", "15555"))
+
+# staring_nonce is the nonce number that maps to the transfer of the first account in the list
+# it is used to ensure each transfer is idempotent
+# be careful when you change it
+starting_nonce = 3
+
+batch_size = 20
+query_timeout = 10
+
+def queryNonce():
+    params = {
+        "json":True,
+        "code":EVM_CONTRACT,
+        "scope":EVM_CONTRACT,
+        "table":"account",
+        "table_key":"",
+        "lower_bound":_from,
+        "upper_bound":_from,
+        "limit":1,
+        "key_type":"sha256",
+        "index_position":"2",
+        "encode_type":"dec",
+        "reverse":False,
+        "show_payer":False
+    }
+    resp = requests.post(url=NODEOS_ENDPOINT + "/v1/chain/get_table_rows", data=json.dumps(params))
+    data = resp.json() # Check the JSON Response Content documentation below
+    #print("response is {}".format(data))
+    nonce = data["rows"][0]["nonce"]
+    return nonce
+
+if len(sys.argv) < 3:
+    print("{0} FROM_ACCOUNT CSV_FILE".format(sys.argv[0]))
+    sys.exit(1)
+
+_from = sys.argv[1].lower()
+if _from[:2] == '0x': _from = _from[2:]
+
+print("reading accounts from {}...".format(sys.argv[2]))
+to_acc_bals = []
+with open(sys.argv[2], 'r') as file:
+    reader = csv.reader(file)
+    for row in reader:
+        acc = row[0]
+        if acc[:2] == '0x': 
+            acc = acc[2:]
+        bal = int(row[1])
+        unsigned_tx = transactions.Transaction(
+            starting_nonce + len(to_acc_bals),
+            150000000000, #150 GWei
+            100000,       #100k Gas
+            acc,
+            bal,
+            b''
+        )
+        rlptx = rlp.encode(unsigned_tx.sign(EVM_SENDER_KEY, EVM_CHAINID), transactions.Transaction)
+        to_acc_bals.append([acc, bal, rlptx.hex()])
+
+print("{} accounts loaded from {}".format(len(to_acc_bals), sys.argv[2]))
+
+current_nonce = queryNonce()
+print("current nonce is {}".format(current_nonce))
+
+if starting_nonce != current_nonce:
+    print("WARNING! nonce value not same, will continue from the last point")
+
+last_query_time = time.time()
+while current_nonce - starting_nonce < len(to_acc_bals):
+    i = current_nonce - starting_nonce
+    batch_end = i + batch_size
+
+    print("distribute {} to account {}, nonce {}".format(to_acc_bals[i][1], to_acc_bals[i][0], starting_nonce + i))
+    act_data = {"ram_payer":EOS_SENDER, "rlptx":to_acc_bals[i][2]}
+    result = subprocess.run(["./cleos", "-u", NODEOS_ENDPOINT, "push", "action", EVM_CONTRACT, "pushtx", json.dumps(act_data), "-p", EOS_SENDER, "-s", "-j", "-d"], capture_output=True, text=True)
+    txn_json = json.loads(result.stdout)
+    i = i + 1
+    current_nonce = current_nonce + 1
+
+    while i < batch_end and i < len(to_acc_bals):
+        print("distribute {} to account {}, nonce {}".format(to_acc_bals[i][1], to_acc_bals[i][0], starting_nonce + i))
+        act_data = {"ram_payer":EOS_SENDER, "rlptx":to_acc_bals[i][2]}
+        act_json = json.loads(json.dumps(txn_json["actions"][0]))
+        act_json["data"] = act_data
+        txn_json["actions"].append(act_json)
+        i = i + 1
+        current_nonce = current_nonce + 1
+
+    #print("txn_json is {}".format(txn_json))
+    subprocess.run(["./cleos", "-u", NODEOS_ENDPOINT, "push", "transaction", json.dumps(txn_json)], capture_output=True, text=True)
+
+    # resync current nonce, in case transactions fail
+    if time.time() - last_query_time >= query_timeout:
+        current_nonce = queryNonce()
+        if current_nonce - starting_nonce == len(to_acc_bals):
+            time.sleep(query_timeout)
+            current_nonce = queryNonce()
+        print("current nonce is {}".format(current_nonce))
+        last_query_time = time.time()
+
+print("Successfully distribute tokens to {} accounts".format(len(to_acc_bals)))
+sys.exit(0)


### PR DESCRIPTION
Token distribution script.

This script will distribute initial EVM tokens to list of accounts defined in CSV format, such as:
```
0x00000000219ab540356cbb839cbe05303d7705fa,14708999007718564869804029
0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2,3930560351933256293096325
0xf977814e90da44bfa03b6295a0616a897441acec,2604596263728749700480557
0xda9dfa130df4de4673b89022ee50ff26f6ea73cf,2113030086367224616200000
0x0716a17fbaee714f1e6ab0f9d59edbc5f09815c0,1998606574289842563751000
0xbe0eb53f46cd790cd13851d5eff43d12404d33e8,1996008352588563830743490
0x742d35cc6634c0532925a3b844bc454e4438f44e,1383424850937541446672785
0x8315177ab297ba92a06054ce80a67ed4dbd7ed3a,708156503751201890716611
0x07ee55aa48bb72dcc6e9d78256648910de513eca,604196048022935468400001
0xdc24316b9ae028f1497c275eb9192a3ea0f67022,601959590462425623040360
0xa7efae728d2936e78bda97dc267687568dd593f3,543669389318256711774267
0x61edcdf5bb737adffe5043706e7c5bb1f1a56eea,479498953581340000000001
0xe92d1a43df510f82c66382592a047d288f85226f,450000050102927158850785
0x0548f59fee79f8832c299e01dca5c76f034f558e,392081739617866237571012
0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5,366455515698463151651144
0x1b3cb81e51011b549d78bf720b0d924ac763a7c2,347300004142218027746099
0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae,339271322894873395679776
0xdf9eb223bafbe5c5271415c75aecd68c21fe3d7f,330030170762901147705141
0xca8fa8f0b631ecdb18cda619c4fc9d197c8affca,325000481655758268096499
0x9bec8d9d62c68792cea3123a231fb8c31f140f3d,322743487311032029621101
0xc098b2a3aa256d2140208c3de6543aaef5cd3a94,306986156836207029572641
0x3bfc20f0b9afcace800d73d2191166ff16540258,306276635371399926202000
0x220866b1a2219f40e72f5c628b65d54268ca3a9d,290001009377701567100010
0x6262998ced04146fa42253a5c0af90ca02dfd2a3,284977023352706283678140
0x8103683202aa8da10536036edef04cdd865c225e,275000028042465694496868
0x78605df79524164911c144801f41e9811b7db73d,269946632867765761986325
0x8484ef722627bf18ca5ae6bcf031c23e6e922b30,263929271023516551514723
0x176f3dab24a159341c0509bb36b833e7fdd0a132,254280579801332468059180
0x0a4c79ce84202b03e95b7a692e5d728d83c44c76,254248454025158027746099
0x5a52e96bacdabb82fd05763e25335261b270efcb,250000066559466741827733
0x2b6ed29a95753c3ad948348e3e7b1a251080ffb9,250000017063189357289820
0x189b9cbd4aff470af2c0102f365fc1823d857965,248501549330399008138107
0x9acb5ce4878144a74eeededa54c675aa59e0d3d2,247980494352767282092107
0x25eaff5b179f209cf186b1cdcbfa463a69df4c45,243118414047721611866847
0x9845e1909dca337944a0272f1f9f7249833d2d19,240001204790709539800924
0xb7b9526e61738032cefaaaea37164e279ab87c76,231831107586186200649626
0xb29380ffc20696729b7ab8d093fa1e2ec14dfe2b,231691690612586491556821
0x99c9fc46f92e8a1c0dec1b1747d010903e884be1,223794489517979645533220
0x756d64dc5edb56740fc617628dc832ddbcfd373c,221567311609520000000000
0xbddf00563c9abd25b576017f08c46982012f12be,219697276467000000000666
```
It uses the "from" account's nonce number as the state check to make sure the whole token distribution process is idempotent


Dependencies:
keosd, cleos, python3

usage: 
```python3 ./distribute_to_accounts.py FROM_ACCOUNT DISTRIBUTION_CSV```

example usage:
1.prepare your Antelope private key in local keosd
2. run
```
export EVM_SENDER_KEY=a3f1b69da92a0233ce29485d3049a4ace39e8d384bbc2557e3fc60940ce4e954
export NODEOS_ENDPOINT=http://127.0.0.1:8888
python3 ./distribute_to_accounts.py 2787b98fc4e731d0456b3941f0b3fe2e01439961 ~/Downloads/eth_acc_bals_100k.csv
```

