### PR TITLE
fix broken RPC-metamask communications

### DIFF
--- a/silkrpc/http/request_parser.cpp
+++ b/silkrpc/http/request_parser.cpp
@@ -214,7 +214,11 @@ RequestParser::ResultType RequestParser::consume(Request& req, char input) {
                         return h.name == "Content-Length";
                     });
                     if (it == req.headers.end()) {
-                        return bad;
+                        if (req.method != "OPTIONS") {
+                            return bad;
+                        } else {
+                            return good;
+                        }
                     }
                     req.content_length = std::atoi((*it).value.c_str());
                 }

--- a/silkrpc/json/types.cpp
+++ b/silkrpc/json/types.cpp
@@ -634,20 +634,20 @@ void to_json(nlohmann::json& json, const std::set<evmc::address>& addresses) {
     }
 }
 
-nlohmann::json make_json_content(uint32_t id) {
+nlohmann::json make_json_content(const nlohmann::json& id) {
     return {{"jsonrpc", "2.0"}, {"id", id}, {"result", nullptr}};
 }
 
-nlohmann::json make_json_content(uint32_t id, const nlohmann::json& result) {
+nlohmann::json make_json_content(const nlohmann::json& id, const nlohmann::json& result) {
     return {{"jsonrpc", "2.0"}, {"id", id}, {"result", result}};
 }
 
-nlohmann::json make_json_error(uint32_t id, int32_t code, const std::string& message) {
+nlohmann::json make_json_error(const nlohmann::json& id, int32_t code, const std::string& message) {
     const Error error{code, message};
     return {{"jsonrpc", "2.0"}, {"id", id}, {"error", error}};
 }
 
-nlohmann::json make_json_error(uint32_t id, const RevertError& error) {
+nlohmann::json make_json_error(const nlohmann::json& id, const RevertError& error) {
     return {{"jsonrpc", "2.0"}, {"id", id}, {"error", error}};
 }
 

--- a/silkrpc/json/types.hpp
+++ b/silkrpc/json/types.hpp
@@ -124,10 +124,10 @@ std::string to_quantity(uint64_t number);
 std::string to_quantity(intx::uint256 number);
 std::string to_quantity(silkworm::ByteView bytes);
 
-nlohmann::json make_json_content(uint32_t id);
-nlohmann::json make_json_content(uint32_t id, const nlohmann::json& result);
-nlohmann::json make_json_error(uint32_t id, int32_t code, const std::string& message);
-nlohmann::json make_json_error(uint32_t id, const RevertError& error);
+nlohmann::json make_json_content(const nlohmann::json& id);
+nlohmann::json make_json_content(const nlohmann::json& id, const nlohmann::json& result);
+nlohmann::json make_json_error(const nlohmann::json& id, int32_t code, const std::string& message);
+nlohmann::json make_json_error(const nlohmann::json& id, const RevertError& error);
 
 } // namespace silkrpc
 


### PR DESCRIPTION
Fix broken communications between TrustEVM-RPC and metamask plugin in Chrome

- the type of values of "id" field can be string or integer or whatever json object
- support HTTP OPTIONS request (with empty content)

