### PR TITLE
Shutdown trustevm-node when connection to SHiP is lost

### DIFF
--- a/cmd/ship_receiver_plugin.cpp
+++ b/cmd/ship_receiver_plugin.cpp
@@ -120,15 +120,15 @@ class ship_receiver_plugin_impl : std::enable_shared_from_this<ship_receiver_plu
       template <typename F>
       inline void async_read(F&& func) const {
          auto buff = std::make_shared<flat_buffer>();
-         boost::system::error_code ec;
 
          stream->async_read(*buff, appbase::app().get_priority_queue().wrap(80,
-            [this, buff, func](const auto ec, auto) {
+            [buff, func](const auto ec, auto) {
                if (ec) {
                   SILK_CRIT << "SHiP read failed : " << ec.message();
                   sys::error();
+               } else {
+                  func(buff);
                }
-               func(buff);
             })
          );
       }

--- a/cmd/sys_plugin.hpp
+++ b/cmd/sys_plugin.hpp
@@ -20,8 +20,9 @@ class sys_plugin : public appbase::plugin<sys_plugin> {
       }
 
       static inline void error() {
-         raise(SIGTERM);
-         raise(SIGINT);
+         appbase::app().quit();
+         //raise(SIGTERM);
+         //raise(SIGINT);
       }
 
       uint32_t get_verbosity();


### PR DESCRIPTION
Fix shutdown of trustevm-node when SHiP connection is lost.

Resolves #214 