### PR TITLE
Add ship-start-from-block-id & ship-start-from-block-timestamp option.

### DIFF
--- a/cmd/ship_receiver_plugin.cpp
+++ b/cmd/ship_receiver_plugin.cpp
@@ -1,5 +1,6 @@
 #include "ship_receiver_plugin.hpp"
 #include "abi_utils.hpp"
+#include "utils.hpp"
 
 #include <string>
 #include <utility>
@@ -28,12 +29,14 @@ class ship_receiver_plugin_impl : std::enable_shared_from_this<ship_receiver_plu
       using native_block_t = channels::native_block;
       static constexpr eosio::name pushtx = eosio::name("pushtx");
 
-      void init(std::string h, std::string p, eosio::name ca, std::optional<uint32_t> start_block_num) {
+      void init(std::string h, std::string p, eosio::name ca,
+                std::optional<eosio::checksum256> start_block_id, int64_t start_block_timestamp) {
          SILK_DEBUG << "ship_receiver_plugin_impl INIT";
          host = std::move(h);
          port = std::move(p);
          core_account = ca;
-         start_from_block_num = start_block_num;
+         start_from_block_id = start_block_id;
+         start_from_block_timestamp = start_block_timestamp;
          resolver = std::make_shared<tcp::resolver>(appbase::app().get_io_service());
          stream   = std::make_shared<websocket::stream<tcp::socket>>(appbase::app().get_io_service());
          stream->binary(true);
@@ -247,15 +250,6 @@ class ship_receiver_plugin_impl : std::enable_shared_from_this<ship_receiver_plu
          });
       }
 
-      inline uint32_t endian_reverse_u32( uint32_t x )
-      {
-         return (((x >> 0x18) & 0xFF)        )
-            | (((x >> 0x10) & 0xFF) << 0x08)
-            | (((x >> 0x08) & 0xFF) << 0x10)
-            | (((x        ) & 0xFF) << 0x18)
-            ;
-      }
-
       void sync() {
          // get available blocks range we can grab
          auto res = get_status();
@@ -265,12 +259,13 @@ class ship_receiver_plugin_impl : std::enable_shared_from_this<ship_receiver_plu
             sys::error("Unable to read canonical header");
             return;
          }
-         auto start_from = endian_reverse_u32(*reinterpret_cast<uint32_t*>(head_header->mix_hash.bytes)) + 1;
+         auto start_from = utils::to_block_num(head_header->mix_hash.bytes) + 1;
          SILK_INFO << "Canonical header start from block: " << start_from;
 
-         if( start_from_block_num ) {
-            SILK_INFO << "Using specified start block number:" << *start_from_block_num;
-            start_from = *start_from_block_num;
+         if( start_from_block_id ) {
+            uint32_t block_num = utils::to_block_num(*start_from_block_id);
+            SILK_INFO << "Using specified start block number:" << block_num;
+            start_from = block_num;
          }
 
          if( res.trace_begin_block > start_from ) {
@@ -284,6 +279,16 @@ class ship_receiver_plugin_impl : std::enable_shared_from_this<ship_receiver_plu
          start_read();
       }
 
+      std::optional<channels::native_block> get_start_from_block() {
+         if( !start_from_block_id ) return {};
+
+         channels::native_block nb{};
+         nb.id = *start_from_block_id;
+         nb.timestamp = start_from_block_timestamp;
+         nb.block_num = utils::to_block_num(*start_from_block_id);
+         return nb;
+      }
+
    private:
       std::shared_ptr<tcp::resolver>                  resolver;
       std::shared_ptr<websocket::stream<tcp::socket>> stream;
@@ -293,7 +298,8 @@ class ship_receiver_plugin_impl : std::enable_shared_from_this<ship_receiver_plu
       abieos::abi                                     abi;
       channels::native_blocks::channel_type&          native_blocks_channel;
       eosio::name                                     core_account;
-      std::optional<uint32_t>                         start_from_block_num;
+      std::optional<eosio::checksum256>               start_from_block_id;
+      int64_t                                         start_from_block_timestamp{};
 };
 
 ship_receiver_plugin::ship_receiver_plugin() : my(new ship_receiver_plugin_impl) {}
@@ -305,8 +311,10 @@ void ship_receiver_plugin::set_program_options( appbase::options_description& cl
         "SHiP host address")
       ("ship-core-account", boost::program_options::value<std::string>()->default_value("evmevmevmevm"),
         "Account on the core blockchain that hosts the Trust EVM runtime")
-      ("ship-start-from-block-num", boost::program_options::value<uint32_t>(),
-        "Override Antelope block number to start syncing from"  )
+      ("ship-start-from-block-id", boost::program_options::value<std::string>(),
+        "Override Antelope block id to start syncing from"  )
+      ("ship-start-from-block-timestamp", boost::program_options::value<int64_t>(),
+        "Timestamp for the provided ship-start-from-block-id, required if block-id provided"  )
    ;
 }
 
@@ -314,12 +322,20 @@ void ship_receiver_plugin::plugin_initialize( const appbase::variables_map& opti
    auto endpoint = options.at("ship-endpoint").as<std::string>();
    const auto& i = endpoint.find(":");
    auto core     = options.at("ship-core-account").as<std::string>();
-   std::optional<uint32_t> start_block_num;
-   if (options.contains("ship-start-from-block-num")) {
-      start_block_num = options.at("ship-start-from-block-num").as<uint32_t>();
+   std::optional<eosio::checksum256> start_block_id;
+   int64_t start_block_timestamp = 0;
+   if (options.contains("ship-start-from-block-id")) {
+      if (!options.contains("ship-start-from-block-timestamp")) {
+         throw std::runtime_error("ship-start-from-block-timestamp required if ship-start-from-block-id provided");
+      }
+      start_block_id = utils::checksum256_from_string( options.at("ship-start-from-block-id").as<std::string>() );
+      start_block_timestamp = options.at("ship-start-from-block-timestamp").as<int64_t>();
+      SILK_INFO << "String from block id: " << utils::to_string( *start_block_id ) << " block num: " << utils::to_block_num(*start_block_id);
+   } else if ( options.contains("ship-start-from-block-timestamp") ) {
+      throw std::runtime_error("ship-start-from-block-timestamp only valid if ship-start-from-block-id provided");
    }
 
-   my->init(endpoint.substr(0, i), endpoint.substr(i+1), eosio::name(core), start_block_num);
+   my->init(endpoint.substr(0, i), endpoint.substr(i+1), eosio::name(core), start_block_id, start_block_timestamp);
    SILK_INFO << "Initialized SHiP Receiver Plugin";
 }
 
@@ -331,4 +347,8 @@ void ship_receiver_plugin::plugin_startup() {
 
 void ship_receiver_plugin::plugin_shutdown() {
    SILK_INFO << "Shutdown SHiP Receiver";
+}
+
+std::optional<channels::native_block> ship_receiver_plugin::get_start_from_block() {
+   return my->get_start_from_block();
 }

--- a/cmd/ship_receiver_plugin.hpp
+++ b/cmd/ship_receiver_plugin.hpp
@@ -22,6 +22,8 @@ class ship_receiver_plugin : public appbase::plugin<ship_receiver_plugin> {
       void plugin_startup();
       void plugin_shutdown();
 
+      std::optional<channels::native_block> get_start_from_block();
+
    private:
       std::unique_ptr<class ship_receiver_plugin_impl> my;
 };

--- a/cmd/utils.hpp
+++ b/cmd/utils.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <eosio/ship_protocol.hpp>
+
+#include <silkworm/common/util.hpp>
+#include <silkworm/common/log.hpp>
+
+namespace utils {
+
+    inline std::string to_string(const eosio::checksum256& cs) {
+        auto bytes = cs.extract_as_byte_array();
+        return silkworm::to_hex(bytes, false);
+    }
+
+    inline eosio::checksum256 checksum256_from_string(std::string_view s) {
+        std::optional<silkworm::Bytes> bytes = silkworm::from_hex(s);
+        if ( bytes ) {
+            std::array<uint8_t, 32> data{};
+            if ( data.size() == bytes->size() ) {
+                std::memcpy(data.data(), bytes->data(), bytes->size());
+                return eosio::checksum256{data};
+            }
+        }
+
+        std::string err = "Unable to convert to checksum256: ";
+        err += s;
+        throw std::runtime_error(err);
+    }
+
+    inline uint32_t endian_reverse_u32( uint32_t x ) {
+        return (((x >> 0x18) & 0xFF)        )
+               | (((x >> 0x10) & 0xFF) << 0x08)
+               | (((x >> 0x08) & 0xFF) << 0x10)
+               | (((x        ) & 0xFF) << 0x18)
+            ;
+    }
+
+    inline uint32_t to_block_num(const evmc::bytes32& b) {
+        return endian_reverse_u32(*reinterpret_cast<const uint32_t*>(b.bytes));
+    }
+
+    inline uint32_t to_block_num(const eosio::checksum256& cs) {
+        return endian_reverse_u32(*reinterpret_cast<uint32_t*>(cs.extract_as_byte_array().data()));
+    }
+
+} // namespace utils


### PR DESCRIPTION
Add `ship-start-from-block-id` & `ship-start-from-block-timestamp` to `ship_receiver_plugin`.

Resolves #233 