### PR TITLE
Fix lifetime issue with Tracers passed to EVMExecutor::call

### DIFF
--- a/silkrpc/commands/eth_api.cpp
+++ b/silkrpc/commands/eth_api.cpp
@@ -1126,13 +1126,13 @@ boost::asio::awaitable<void> EthereumRpcApi::handle_eth_create_access_list(const
 
         auto tracer = std::make_shared<AccessListTracer>(*call.from, to);
 
-        Tracers tracers{tracer};
         bool access_lists_match{false};
         do {
             EVMExecutor executor{*context_.io_context(), tx_database, *chain_config_ptr, workers_, block_with_hash.block.header.number};
             const auto txn = call.to_transaction();
             tracer->reset_access_list();
-            const auto execution_result = co_await executor.call(block_with_hash.block, txn, /* refund */true, /* gasBailout */false, tracers);
+            Tracers tracers{tracer};
+            const auto execution_result = co_await executor.call(block_with_hash.block, txn, /* refund */true, /* gasBailout */false, std::move(tracers));
             if (execution_result.pre_check_error) {
                 reply = make_json_error(request["id"], -32000, execution_result.pre_check_error.value());
                 break;

--- a/silkrpc/core/evm_debug.cpp
+++ b/silkrpc/core/evm_debug.cpp
@@ -278,7 +278,7 @@ boost::asio::awaitable<std::vector<DebugTrace>> DebugExecutor<WorldState, VM>::e
         auto debug_tracer = std::make_shared<debug::DebugTracer>(debug_trace.debug_logs, config_);
 
         silkrpc::Tracers tracers{debug_tracer};
-        const auto execution_result = co_await executor.call(block, txn, /* refund */false, /* gasBailout */false, tracers);
+        const auto execution_result = co_await executor.call(block, txn, /* refund */false, /* gasBailout */false, std::move(tracers));
 
         if (execution_result.pre_check_error) {
             SILKRPC_DEBUG << "debug failed: " << execution_result.pre_check_error.value() << "\n";
@@ -331,7 +331,7 @@ boost::asio::awaitable<DebugExecutorResult> DebugExecutor<WorldState, VM>::execu
     auto debug_tracer = std::make_shared<debug::DebugTracer>(debug_trace.debug_logs, config_);
 
     silkrpc::Tracers tracers{debug_tracer};
-    const auto execution_result = co_await executor.call(block, transaction, /* refund */ true, /* gasBailout*/ false, tracers);
+    const auto execution_result = co_await executor.call(block, transaction, /* refund */ true, /* gasBailout*/ false, std::move(tracers));
 
     if (execution_result.pre_check_error) {
         result.pre_check_error = "tracing failed: " + execution_result.pre_check_error.value();

--- a/silkrpc/core/evm_executor.hpp
+++ b/silkrpc/core/evm_executor.hpp
@@ -66,7 +66,7 @@ public:
     EVMExecutor(const EVMExecutor&) = delete;
     EVMExecutor& operator=(const EVMExecutor&) = delete;
 
-    boost::asio::awaitable<ExecutionResult> call(const silkworm::Block& block, const silkworm::Transaction& txn, bool refund = true, bool gas_bailout = false, const Tracers& tracers = {});
+    boost::asio::awaitable<ExecutionResult> call(const silkworm::Block& block, const silkworm::Transaction& txn, bool refund = true, bool gas_bailout = false, Tracers tracers = {});
     void reset();
 
 private:

--- a/silkrpc/core/evm_trace.cpp
+++ b/silkrpc/core/evm_trace.cpp
@@ -1091,7 +1091,7 @@ boost::asio::awaitable<std::vector<TraceCallResult>> TraceCallExecutor<WorldStat
 
         tracers.push_back(ibsTracer);
 
-        auto execution_result = co_await executor.call(block, transaction, /*refund=*/true, /*gas_bailout=*/true, tracers);
+        auto execution_result = co_await executor.call(block, transaction, /*refund=*/true, /*gas_bailout=*/true, std::move(tracers));
         if (execution_result.pre_check_error) {
             result.pre_check_error = execution_result.pre_check_error.value();
         } else {
@@ -1152,7 +1152,7 @@ boost::asio::awaitable<TraceManyCallResult> TraceCallExecutor<WorldState, VM>::t
         }
         tracers.push_back(ibsTracer);
 
-        auto execution_result = co_await executor.call(block, transaction, /*refund=*/true, /*gas_bailout=*/true, tracers);
+        auto execution_result = co_await executor.call(block, transaction, /*refund=*/true, /*gas_bailout=*/true, std::move(tracers));
 
         if (execution_result.pre_check_error) {
             result.pre_check_error = "first run for txIndex " + std::to_string(index) + " error: " + execution_result.pre_check_error.value();
@@ -1242,7 +1242,7 @@ boost::asio::awaitable<TraceCallResult> TraceCallExecutor<WorldState, VM>::execu
         std::shared_ptr<silkworm::EvmTracer> tracer = std::make_shared<trace::StateDiffTracer>(traces.state_diff.value(), state_addresses);
         tracers.push_back(tracer);
     }
-    auto execution_result = co_await executor.call(block, transaction, /*refund=*/true, /*gas_bailout=*/true, tracers);
+    auto execution_result = co_await executor.call(block, transaction, /*refund=*/true, /*gas_bailout=*/true, std::move(tracers));
 
     if (execution_result.pre_check_error) {
         result.pre_check_error = execution_result.pre_check_error.value();


### PR DESCRIPTION
These changes should be pushed upstream to https://github.com/torquem-ch/silkrpc

Resolves #240 