### PR TITLE
BOOST_REQUIRE() no failures in contract unit tests

### DIFF
--- a/contract/tests/evm_runtime_tests.cpp
+++ b/contract/tests/evm_runtime_tests.cpp
@@ -1040,5 +1040,7 @@ BOOST_FIXTURE_TEST_CASE( GeneralStateTests, evm_runtime_tester ) try {
    const auto [_, duration] = sw.lap();
    std::cout << " in " << StopWatch::format(duration) << std::endl;
 
+   BOOST_REQUIRE_EQUAL(total_failed, 0);
+
 } FC_LOG_AND_RETHROW()
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The contract `unit_test` prints out failures and a summary such as
```
7128 tests passed, 166 failed, 2 skipped in 2m 22s
```
However these failure prints are swallowed by `ctest` (by default) and `unit_test` always has a return code of 0. i.e. current behavior is deceptive because just running `ctest` suggests everything is passing when in reality everything could be failing.

Add a boost test requirement that there are no failing tests so that `ctest` complains and return code is non-zero when any tests are failing. Currently 166 tests are failing for me.