### PR TITLE
Create a .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,16 @@ cmake-build-debug
 *.lai
 *.lib
 
+# data
+*.csv
+*.html
+*.json
+*.tsv
+*.xhtml
+*.xls
+*.xlsx
+*.xml
+
 # editor files
 .ccls-cache
 .idea


### PR DESCRIPTION
From TrustEVM [issue 242](https://github.com/eosnetworkfoundation/TrustEVM/issues/242), this pull request adds a `.gitignore` file that I mostly copied from [CDT](https://github.com/AntelopeIO/cdt/blob/v3.1.0/.gitignore) which will help prevent contributors from accidentally committing files that should not be checked in such as build artifacts, archives, or data sets.

## See Also
- TrustEVM
  - [Pull Request 277](https://github.com/eosnetworkfoundation/TrustEVM/pull/277) - Create a `.gitignore`
  - [Pull Request 278](https://github.com/eosnetworkfoundation/TrustEVM/pull/278) - Delete Circle CI Config
  - [Pull Request 291](https://github.com/eosnetworkfoundation/TrustEVM/pull/291) - TrustEVM Node CI
  - [Pull Request 293](https://github.com/eosnetworkfoundation/TrustEVM/pull/293) - TrustEVM Contract CI
  - [Pull Request 301](https://github.com/eosnetworkfoundation/TrustEVM/pull/301) - Expand `.gitignore`
  - [Pull Request 311](https://github.com/eosnetworkfoundation/TrustEVM/pull/311) - Remove `-Deosio_DIR` `cmake` Flag from Contract Tests
  - [Pull Request 312](https://github.com/eosnetworkfoundation/TrustEVM/pull/312) - Run TrustEVM Contract Tests in CI
- github-app-token-action
  > Each of these PRs were PRed upstream as well.
  - [Pull Request 1](https://github.com/AntelopeIO/github-app-token-action/pull/1) - Security - Bump json5 from 1.0.1 to 1.0.2
  - [Pull Request 3](https://github.com/AntelopeIO/github-app-token-action/pull/3) - Documentation
  - [Pull Request 4](https://github.com/AntelopeIO/github-app-token-action/pull/4) - Security - Address CVE-2022-46175 in json5
  - [Pull Request 5](https://github.com/AntelopeIO/github-app-token-action/pull/5) - Security - Upgrade octokit/auth-app from 4.0.7 to 4.0.9 to Address CVEs
