### PR TITLE
reduce contract cmake requirement to 3.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ make -j8
 
 ### compile EVM smart contract for Antelope blockchain:
 Prerequisites:
-- cmake 3.19 or later
+- cmake 3.16 or later
 - install cdt
 ```
 wget https://github.com/AntelopeIO/cdt/releases/download/v3.1.0/cdt_3.1.0_amd64.deb

--- a/contract/CMakeLists.txt
+++ b/contract/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.16)
 project(evm_runtime)
 
 include(ExternalProject)

--- a/contract/src/CMakeLists.txt
+++ b/contract/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.16)
 project(evm_runtime)
 
 set(EOSIO_WASM_OLD_BEHAVIOR "Off")

--- a/docs/compilation_and_testing_guide.md
+++ b/docs/compilation_and_testing_guide.md
@@ -2,7 +2,7 @@
  
 Prerequisite:
 
-   cmake 3.19 or later
+   cmake 3.16 or later
    Compile and install cdt project (https://github.com/AntelopeIO/cdt.git), please refer to https://github.com/AntelopeIO/cdt. 
    After install, you need to ensure the following soft links exist (if not, please manually create these soft links). 
    


### PR DESCRIPTION
Not sure where the original 3.19 came from. Reducing to 3.16 makes it easier to build in ubuntu 20 (which is the only version of leap-dev.deb we build currently), and the build worked for me there.