### PR TITLE
use secp256k1 include dir from silkworm's silkpre; not leap's build directory

### DIFF
--- a/contract/tests/CMakeLists.txt
+++ b/contract/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/../external/intx/include
     ${CMAKE_SOURCE_DIR}/../external/ethash/include
     ${CMAKE_SOURCE_DIR}/external
-    ${eosio_DIR}/../../../../libraries/fc/secp256k1/secp256k1/include
+    ${CMAKE_SOURCE_DIR}/../../silkworm/third_party/silkpre/third_party/secp256k1/include
 )
 
 #file(GLOB UNIT_TESTS "*.cpp" "*.hpp")


### PR DESCRIPTION
I've locally had this line changed ever since working on the project; it seems to be trying to use libsecp256k1's include files from Leap's source directory. Besides likely not working 3.2+ (where `fc` has been renamed `libfc`), `eosio_DIR` might not even be the source directory if using a `make install`ed Leap, or a `leap-dev.deb`

So use the secp256k1 header directory from silkworm's silkpre. I suspect this is the more proper include directory to use anyways, since I believe the need for these header files are due to stuff in silkworm.