### PR TITLE
Expand .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,13 +56,16 @@ cmake-build-debug
 # executables
 *.apk
 *.app
+*.AppImage
 *.com
+*.deb
 *.dll
 *.dmg
 *.exe
 *.jar
 *.msi
 *.out
+*.rpm
 
 # logs
 *.log


### PR DESCRIPTION
Following [pull request 277](https://github.com/eosnetworkfoundation/TrustEVM/pull/277) from TrustEVM [issue 242](https://github.com/eosnetworkfoundation/TrustEVM/issues/242), this pull request expands the `.gitignore` to include more spreadsheet file formats, databases, archives, and executables for various platforms.

_Why?_

I am working with a Linux executable in the repo, waiting on builds, and seeing it in the `git` staging ground annoys me. We don't want anyone checking in this kind of stuff. Plus I can copy/pasta this to other repos.

## See Also
- TrustEVM
  - [Pull Request 277](https://github.com/eosnetworkfoundation/TrustEVM/pull/277) - Create a `.gitignore`
  - [Pull Request 278](https://github.com/eosnetworkfoundation/TrustEVM/pull/278) - Delete Circle CI Config
  - [Pull Request 291](https://github.com/eosnetworkfoundation/TrustEVM/pull/291) - TrustEVM Node CI
  - [Pull Request 293](https://github.com/eosnetworkfoundation/TrustEVM/pull/293) - TrustEVM Contract CI
  - [Pull Request 301](https://github.com/eosnetworkfoundation/TrustEVM/pull/301) - Expand `.gitignore`
  - [Pull Request 311](https://github.com/eosnetworkfoundation/TrustEVM/pull/311) - Remove `-Deosio_DIR` `cmake` Flag from Contract Tests
  - [Pull Request 312](https://github.com/eosnetworkfoundation/TrustEVM/pull/312) - Run TrustEVM Contract Tests in CI
- github-app-token-action
  > Each of these PRs were PRed upstream as well.
  - [Pull Request 1](https://github.com/AntelopeIO/github-app-token-action/pull/1) - Security - Bump json5 from 1.0.1 to 1.0.2
  - [Pull Request 3](https://github.com/AntelopeIO/github-app-token-action/pull/3) - Documentation
  - [Pull Request 4](https://github.com/AntelopeIO/github-app-token-action/pull/4) - Security - Address CVE-2022-46175 in json5
  - [Pull Request 5](https://github.com/AntelopeIO/github-app-token-action/pull/5) - Security - Upgrade octokit/auth-app from 4.0.7 to 4.0.9 to Address CVEs
