### PR TITLE
run EVM contract unit tests with EOS VM OC to decrease test time

### DIFF
--- a/contract/tests/CMakeLists.txt
+++ b/contract/tests/CMakeLists.txt
@@ -23,7 +23,7 @@ include_directories(
 
 set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -Wno-deprecated-declarations")
 
-add_eosio_test( unit_test 
+add_eosio_test_executable( unit_test
     ${CMAKE_SOURCE_DIR}/evm_runtime_tests.cpp
     ${CMAKE_SOURCE_DIR}/init_tests.cpp
     ${CMAKE_SOURCE_DIR}/native_token_tests.cpp
@@ -41,3 +41,5 @@ add_eosio_test( unit_test
     ${CMAKE_SOURCE_DIR}/../external/ethash/lib/ethash/ethash.cpp
     ${CMAKE_SOURCE_DIR}/../external/ethash/lib/ethash/primes.c
 )
+
+add_test(NAME unit_test COMMAND unit_test --report_level=detailed --color_output -- --eos-vm-oc)


### PR DESCRIPTION
Using EOS VM OC to run the EVM unit tests reduces test time to sub 150 seconds for me.