### PR TITLE
remove eosio account name & secondary index from EVM account table

### DIFF
--- a/contract/include/evm_runtime/tables.hpp
+++ b/contract/include/evm_runtime/tables.hpp
@@ -13,15 +13,10 @@ struct [[eosio::table]] [[eosio::contract("evm_contract")]] account {
     bytes       eth_address;
     uint64_t    nonce;
     bytes       balance;
-    name        eos_account;
     bytes       code;
     bytes       code_hash;
 
     uint64_t primary_key()const { return id; }
-
-    uint64_t by_eos_account()const { 
-        return eos_account.value;
-    }
 
     checksum256 by_eth_address()const { 
         return make_key(eth_address);
@@ -43,12 +38,11 @@ struct [[eosio::table]] [[eosio::contract("evm_contract")]] account {
         return res;
     }
 
-    EOSLIB_SERIALIZE(account, (id)(eth_address)(nonce)(balance)(eos_account)(code)(code_hash));
+    EOSLIB_SERIALIZE(account, (id)(eth_address)(nonce)(balance)(code)(code_hash));
 };
 
 typedef multi_index< "account"_n, account,
     indexed_by<"by.address"_n, const_mem_fun<account, checksum256, &account::by_eth_address>>,
-    indexed_by<"by.account"_n, const_mem_fun<account, uint64_t, &account::by_eos_account>>,
     indexed_by<"by.codehash"_n, const_mem_fun<account, checksum256, &account::by_code_hash>>
 > account_table;
 

--- a/contract/tests/evm_runtime_tests.cpp
+++ b/contract/tests/evm_runtime_tests.cpp
@@ -237,7 +237,6 @@ struct account {
    bytes       eth_address;
    uint64_t    nonce;
    bytes       balance;
-   name        eos_account;
    bytes       code;
    bytes       code_hash;
 
@@ -247,13 +246,6 @@ struct account {
       typedef index256_object index_object;
       static name index_name() {
          return account::index_name("by.address"_n);
-      }
-   };
-
-   struct by_account {
-      typedef index64_object index_object;
-      static name index_name() {
-         return account::index_name("by.account"_n);
       }
    };
 
@@ -280,13 +272,11 @@ struct account {
    static name index_name(const name& n) {
       uint64_t index_table_name = table_name().to_uint64_t() & 0xFFFFFFFFFFFFFFF0ULL;
 
-      //0=>by.address, 1=>by.account, 2=>by.codehash
+      //0=>by.address, 1=>by.codehash
       if( n == "by.address"_n ) {
          return name{index_table_name | 0};
-      } else if( n == "by.account"_n ) {
-         return name{index_table_name | 1};
       } else if( n == "by.codehash"_n ) {
-         return name{index_table_name | 2};
+         return name{index_table_name | 1};
       }
 
       dlog("index name not found: ${a}", ("a",n.to_string()));
@@ -320,7 +310,7 @@ struct account {
    }
 
 };
-FC_REFLECT(account, (id)(eth_address)(nonce)(balance)(eos_account)(code)(code_hash));
+FC_REFLECT(account, (id)(eth_address)(nonce)(balance)(code)(code_hash));
 
 struct storage {
    uint64_t id;


### PR DESCRIPTION
This secondary index isn't used and won't be used. Remove it to liberate some RAM per EVM account.