### PR TITLE
Remove "-Deosio_DIR" cmake Flag from Contract Tests

### DIFF
--- a/.github/workflows/build-contract-test.sh
+++ b/.github/workflows/build-contract-test.sh
@@ -18,7 +18,7 @@ cat "$Deosio_DIR/EosioTester.cmake" | grep 'EOSIO_VERSION' | grep -oP "['\"].*['
 ee mkdir -p contract/tests/build
 ee pushd contract/tests
 ee pushd build
-ee "cmake -Deosio_DIR=$Deosio_DIR .."
+ee "cmake .."
 ee make -j "$(nproc)" unit_test
 
 # pack


### PR DESCRIPTION
From TrustEVM [issue 242](https://github.com/eosnetworkfoundation/TrustEVM/issues/242), this pull request forks from [pull request 293](https://github.com/eosnetworkfoundation/TrustEVM/pull/293) to test whether or not the `-Deosio_DIR` flag being passed to `cmake` to indicate the location of the Leap dev files is necessary in CI. I tested this before and I determined it was, but I cannot remember whether this was on my local machine or in CI. I believe it was in CI but I could not find the build. In any case, this branch will determine that and then this pull request will be closed. The pull request is required because I already switched the CI conditions from `on: push` to only on pull requests.

## See Also
- TrustEVM
  - [Pull Request 277](https://github.com/eosnetworkfoundation/TrustEVM/pull/277) - Create a `.gitignore`
  - [Pull Request 278](https://github.com/eosnetworkfoundation/TrustEVM/pull/278) - Delete Circle CI Config
  - [Pull Request 291](https://github.com/eosnetworkfoundation/TrustEVM/pull/291) - TrustEVM Node CI
  - [Pull Request 293](https://github.com/eosnetworkfoundation/TrustEVM/pull/293) - TrustEVM Contract CI
  - [Pull Request 301](https://github.com/eosnetworkfoundation/TrustEVM/pull/301) - Expand `.gitignore`
  - [Pull Request 311](https://github.com/eosnetworkfoundation/TrustEVM/pull/311) - Remove `-Deosio_DIR` `cmake` Flag from Contract Tests
  - [Pull Request 312](https://github.com/eosnetworkfoundation/TrustEVM/pull/312) - Run TrustEVM Contract Tests in CI
- github-app-token-action
  > Each of these PRs were PRed upstream as well.
  - [Pull Request 1](https://github.com/AntelopeIO/github-app-token-action/pull/1) - Security - Bump json5 from 1.0.1 to 1.0.2
  - [Pull Request 3](https://github.com/AntelopeIO/github-app-token-action/pull/3) - Documentation
  - [Pull Request 4](https://github.com/AntelopeIO/github-app-token-action/pull/4) - Security - Address CVE-2022-46175 in json5
  - [Pull Request 5](https://github.com/AntelopeIO/github-app-token-action/pull/5) - Security - Upgrade octokit/auth-app from 4.0.7 to 4.0.9 to Address CVEs
