### PR TITLE
fix too many reader issue, configurable max readers - trustevm-node part

### DIFF
--- a/silkrpc/http/server.cpp
+++ b/silkrpc/http/server.cpp
@@ -75,23 +75,8 @@ boost::asio::awaitable<void> Server::run() {
 
             SILKRPC_DEBUG << "Server::run accepting using io_context " << io_context << "...\n" << std::flush;
 
-            std::shared_ptr<Connection> new_connection;
-
-            do {
-                try {
-                    new_connection = std::make_shared<Connection>(context_, workers_, handler_table_);
-                    co_await acceptor_.async_accept(new_connection->socket(), boost::asio::use_awaitable);
-                    break;
-                } catch (const boost::system::system_error& se) {
-                    if (se.code() == boost::asio::error::no_descriptors) {
-                        SILKRPC_WARN << "Server::run can not accept new connection for now, no descriptor\n" << std::flush;
-                        continue;
-                    } else {
-                        throw;
-                    }
-                }
-            } while (true);
-
+            auto new_connection = std::make_shared<Connection>(context_, workers_, handler_table_);
+            co_await acceptor_.async_accept(new_connection->socket(), boost::asio::use_awaitable);
             if (!acceptor_.is_open()) {
                 SILKRPC_TRACE << "Server::run returning...\n";
                 co_return;
@@ -108,7 +93,7 @@ boost::asio::awaitable<void> Server::run() {
         }
     } catch (const boost::system::system_error& se) {
         if (se.code() != boost::asio::error::operation_aborted) {
-            SILKRPC_ERROR << "Server::run system_error: " << se.code() << " " << se.what() << "\n" << std::flush;
+            SILKRPC_ERROR << "Server::run system_error: " << se.what() << "\n" << std::flush;
             std::rethrow_exception(std::make_exception_ptr(se));
         } else {
             SILKRPC_DEBUG << "Server::run operation_aborted: " << se.what() << "\n" << std::flush;


### PR DESCRIPTION
fix issue #315 - trustevm node part

the following script can be used to do bulk query test:

```
a=3000
while [[ $a -gt 0 ]]; 
do
	echo "starting query, remains $a"
	curl --location --request POST "localhost:8881/" --header 'Content-Type: application/json' --data-raw '{"method":"eth_getLogs","params":[{"fromBlock":"0x1","toBlock":"0xff"}],"id":0,"jsonrpc":"2.0"}' >/dev/null 2>&1 &
	a=$(($a - 1))
done;
exit 0

```