### PR TITLE
remove unused get_block_num() definition

### DIFF
--- a/contract/include/evm_runtime/intrinsics.hpp
+++ b/contract/include/evm_runtime/intrinsics.hpp
@@ -2,9 +2,6 @@
 namespace eosio {
    namespace internal_use_do_not_use {
       extern "C" {
-         __attribute__((eosio_wasm_import))
-         uint32_t get_block_num();
-
         #ifdef WITH_LOGTIME
         __attribute__((eosio_wasm_import))
          void logtime(const char*);


### PR DESCRIPTION
Remove the `get_block_num()` host function definition. We don't use this, and cdt has support for this host function included so we wouldn't need to define it ourselves anyways.