### PR TITLE
Fix gas estimation

### DIFF
--- a/silkrpc/json/types.cpp
+++ b/silkrpc/json/types.cpp
@@ -317,7 +317,7 @@ void from_json(const nlohmann::json& json, Call& call) {
     if (json.count("value") != 0) {
         call.value = json.at("value").get<intx::uint256>();
     }
-    if (json.count("data") != 0) {
+    if (json.count("data") != 0 && !json.at("data").is_null()) {
         const auto json_data = json.at("data").get<std::string>();
         call.data = silkworm::from_hex(json_data);
     }


### PR DESCRIPTION
Metamask calls `eth_estimateGas` API with the `data` field set to `null` which raises an error when silkrpc tries to extract as std::string.

### Request
```javascript
{
    "id": 1361485646256,
    "jsonrpc": "2.0",
    "method": "eth_estimateGas",
    "params": [
        {
            "from": "0x4f3fd0bef272a8a670d4fcf711beed42b0d509a2",
            "value": "0x0",
            "gasPrice": "0x2540be400",
            "data": null,
            "to": "0x70997970c51812dc3a010c7d01b50e0d17dc79c8"
        }
    ]
}
```

### Response
```javascript
{"error":{"code":100,"message":"[json.exception.type_error.302] type must be string, but is null"},"id":1361485646256,"jsonrpc":"2.0"}
```

### Metamask UI

![image](https://user-images.githubusercontent.com/234658/219509086-f53afd75-8e68-488c-a85d-046cf41ba122.png)
