### PR TITLE
run node CI only on PRs, pushes to main&release, and manually

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -2,6 +2,10 @@ name: TrustEVM Node CI
 
 on:
   push:
+    branches:
+      - main
+      - release/*
+  pull_request:
   workflow_dispatch:
     inputs:
       upload-artifacts:


### PR DESCRIPTION
This changes the node CI action's triggers to match that as the contract CI action. Simply being on `push:` seems to be causing it to run on a push to _any_ branch -- even branches not PRed. That's probably a bit much for now.