### PR TITLE
add `-no-missing-ricardian-clause` to contract build

### DIFF
--- a/contract/src/CMakeLists.txt
+++ b/contract/src/CMakeLists.txt
@@ -82,6 +82,8 @@ target_include_directories( evm_runtime PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../../silkworm/third_party/evmone/evmc/include
 )
 
+target_compile_options(evm_runtime PUBLIC --no-missing-ricardian-clause)
+
 if (WITH_LARGE_STACK)
     target_link_options(evm_runtime PUBLIC --stack-size=50000000)
 else()


### PR DESCRIPTION
cuts down on a few warnings