### PR TITLE
remove unused (and removed in Leap's `main`) WAVM header from contract tests

### DIFF
--- a/contract/tests/evm_runtime_tests.cpp
+++ b/contract/tests/evm_runtime_tests.cpp
@@ -14,7 +14,6 @@
 #include <fc/crypto/signature.hpp>
 #include <eosio/chain/exceptions.hpp>
 #include <eosio/chain/fixed_bytes.hpp>
-#include <Runtime/Runtime.h>
 
 #include "eosio.system_tester.hpp"
 

--- a/contract/tests/main.cpp
+++ b/contract/tests/main.cpp
@@ -8,7 +8,6 @@
 #include <boost/test/included/unit_test.hpp>
 #include <fc/log/logger.hpp>
 #include <eosio/chain/exceptions.hpp>
-#include <Runtime/Runtime.h>
 
 #include "eosio.system_tester.hpp"
 


### PR DESCRIPTION
This `Runtime.h` header file was probably copy pasted in at some point. It's unneeded, and causes build failures when using Leap's `main` branch