### PR TITLE
update contract unit tests to work with libtester from 4.0

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -78,8 +78,8 @@ jobs:
         with:
           owner: AntelopeIO
           repo: leap
-          target: 'v3.1.3'
-          prereleases: false
+          target: 'v4.0'
+          prereleases: true
           file: 'leap-dev.*(x86_64|amd64).deb'
           container-package: experimental-binaries
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/contract/tests/basic_evm_tester.hpp
+++ b/contract/tests/basic_evm_tester.hpp
@@ -247,7 +247,7 @@ public:
    // object.
    explicit speculative_block_starter(Tester& tester, uint32_t time_gap_sec = 0) : t(tester)
    {
-      t.control->start_block(t.control->head_block_time() + fc::milliseconds(500 + 1000 * time_gap_sec), 0);
+      t.control->start_block(t.control->head_block_time() + fc::milliseconds(500 + 1000 * time_gap_sec), 0, {}, controller::block_status::incomplete);
    }
 
    speculative_block_starter(speculative_block_starter&& other) : t(other.t) { other.canceled = true; }

--- a/contract/tests/mapping_tests.cpp
+++ b/contract/tests/mapping_tests.cpp
@@ -242,7 +242,7 @@ try {
 
    // Now actually commit the init action into a block to do further testing on top of that state in later blocks.
    {
-      control->start_block(control->head_block_time() + fc::milliseconds(500), 0);
+      control->start_block(control->head_block_time() + fc::milliseconds(500), 0, {}, controller::block_status::incomplete);
       BOOST_REQUIRE_EQUAL(control->pending_block_time().sec_since_epoch(), bm.genesis_timestamp);
 
       init();


### PR DESCRIPTION
`controller::start_block()` has changed in 4.0. Update usage of this function to work with libtester provided from 4.0

🚨 This will break building with libtester from 3.x, so need to hold off merging this PR until appropriate time, whatever that is. I didn't investigate a more general solution (with `ifdef` or the like).