### PR TITLE
proxy cors

### DIFF
--- a/peripherals/proxy/nginx.conf
+++ b/peripherals/proxy/nginx.conf
@@ -3,7 +3,7 @@ worker_processes  5;
 error_log  /var/log/nginx/error.log;
 pid        /var/log/nginx/nginx.pid;
 worker_rlimit_nofile 8192;
-
+user root root;
 events {
   worker_connections  4096;
 }


### PR DESCRIPTION
Fix CORS 
Support WS
Return 204 instead of 500 for GET. This is to prevent people from seeing 500 if he open the api address in browser.