### PR TITLE
upgrade to asset-artifact-download-action@v3; always use ubuntu20's leap-dev.deb

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -49,14 +49,13 @@ jobs:
           token: ${{ steps.auth.outputs.token }}
 
       - name: Download CDT
-        uses: AntelopeIO/asset-artifact-download-action@v2
+        uses: AntelopeIO/asset-artifact-download-action@v3
         with:
           owner: AntelopeIO
           repo: cdt
           target: 'v3.1.0'
           prereleases: false
           file: 'cdt_.*amd64.deb'
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install CDT
         run: sudo apt-get install -y ./cdt*.deb
@@ -74,15 +73,14 @@ jobs:
           if-no-files-found: error
 
       - name: Download Leap - dev binary
-        uses: AntelopeIO/asset-artifact-download-action@v2
+        uses: AntelopeIO/asset-artifact-download-action@v3
         with:
           owner: AntelopeIO
           repo: leap
           target: 'v4.0.3'
           prereleases: false
-          file: 'leap-dev.*(x86_64|amd64).deb'
+          file: 'leap-dev.*ubuntu20.*(x86_64|amd64).deb'
           container-package: experimental-binaries
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Leap
         run: sudo apt-get install -y ./leap*.deb


### PR DESCRIPTION
asset-artifact-download-action@v3 supports walking a commit's parents looking for completed workflows when `target` is a branch/ref (such as `target: main`).

Also, always use the ubuntu20 leap-dev.deb package (this becomes more of a problem for leap 5.0+, which has both available).