### PR TITLE
use libtester 5.0 in CI; use ubuntu 22.04 for CI; use EOS VM OC for tests

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           submodules: 'false'
@@ -23,40 +23,29 @@ jobs:
         run: cat .github/workflows/contract.md >> $GITHUB_STEP_SUMMARY
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         DWITH_TEST_ACTIONS: ['on', 'off']
     name: EOS EVM Contract Build - Tests ${{ matrix.DWITH_TEST_ACTIONS }}
     env:
-      CC: gcc-10
-      CXX: g++-10
       DCMAKE_BUILD_TYPE: 'Release'
 
     steps:
-      - name: Authenticate
-        id: auth
-        uses: AntelopeIO/github-app-token-action@v1
-        with:
-          app_id: ${{ secrets.TRUSTEVM_CI_APP_ID }}
-          private_key: ${{ secrets.TRUSTEVM_CI_APP_KEY }}
-
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: 'recursive'
-          token: ${{ steps.auth.outputs.token }}
 
       - name: Download CDT
-        uses: AntelopeIO/asset-artifact-download-action@v2
+        uses: AntelopeIO/asset-artifact-download-action@v3
         with:
           owner: AntelopeIO
           repo: cdt
           target: 'v3.1.0'
           prereleases: false
           file: 'cdt_.*amd64.deb'
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install CDT
         run: sudo apt-get install -y ./cdt*.deb
@@ -74,15 +63,15 @@ jobs:
           if-no-files-found: error
 
       - name: Download Leap - dev binary
-        uses: AntelopeIO/asset-artifact-download-action@v2
+        uses: AntelopeIO/asset-artifact-download-action@v3
         with:
           owner: AntelopeIO
           repo: leap
-          target: 'v4.0.3'
+          target: 'release/5.0'
           prereleases: false
-          file: 'leap-dev.*(x86_64|amd64).deb'
+          file: 'leap-dev.*ubuntu22\.04_amd64.deb'
           container-package: experimental-binaries
-          token: ${{ secrets.GITHUB_TOKEN }}
+          artifact-name: leap-dev-ubuntu22-amd64
 
       - name: Install Leap
         run: sudo apt-get install -y ./leap*.deb

--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           owner: AntelopeIO
           repo: leap
-          target: 'release/5.0'
+          target: '^5.0.1'
           prereleases: false
           file: 'leap-dev.*ubuntu22\.04_amd64.deb'
           container-package: experimental-binaries

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,7 +52,6 @@ add_eosio_test_executable( unit_test
     ${CMAKE_SOURCE_DIR}/external/ethash/lib/ethash/primes.c
 )
 
-# TODO: add back eos-vm-oc once change to disable EOS VM OC subjective limits during unit test are added
-add_test(NAME consensus_tests COMMAND unit_test --report_level=detailed --color_output --run_test=evm_runtime_tests)
+add_test(NAME consensus_tests COMMAND unit_test --report_level=detailed --color_output --run_test=evm_runtime_tests -- --eos-vm-oc)
 
-add_test(NAME unit_tests COMMAND unit_test --report_level=detailed --color_output --run_test=!evm_runtime_tests)
+add_test(NAME unit_tests COMMAND unit_test --report_level=detailed --color_output --run_test=!evm_runtime_tests -- --eos-vm-oc)

--- a/tests/eosio.system_tester.hpp
+++ b/tests/eosio.system_tester.hpp
@@ -13,25 +13,15 @@ using namespace fc;
 
 using mvo = fc::mutable_variant_object;
 
-#ifndef TESTER
-#ifdef NON_VALIDATING_TEST
-#define TESTER tester
-#else
-#define TESTER validating_tester
-#endif
-#endif
-
 namespace eosio_system {
 
-class eosio_system_tester : public TESTER {
+class eosio_system_tester : public validating_tester {
 public:
-
-   eosio_system_tester()
-   : eosio_system_tester([](TESTER& ) {}){}
-
-   template<typename Lambda>
-   eosio_system_tester(Lambda setup) {
-      setup(*this);
+   eosio_system_tester(const fc::temp_directory& tmpdir)
+   : validating_tester(tmpdir, [](controller::config& cfg) {
+        cfg.eosvmoc_config.cache_size = 1024u*1024*256;
+     }, true) {
+      execute_setup_policy(setup_policy::full);
 
       produce_blocks( 2 );
 
@@ -451,7 +441,7 @@ public:
       }
       produce_blocks( 250);
 
-      auto trace_auth = TESTER::push_action(config::system_account_name, updateauth::get_name(), config::system_account_name, mvo()
+      auto trace_auth = validating_tester::push_action(config::system_account_name, updateauth::get_name(), config::system_account_name, mvo()
                                             ("account", name(config::system_account_name).to_string())
                                             ("permission", name(config::active_name).to_string())
                                             ("parent", name(config::owner_name).to_string())


### PR DESCRIPTION
Move CI to using libtester 5.0. A nice benefit of this is that c++20 can now be used in the EVM tests since libtester 5.0 is compatible with c++20.

But the primary motivation was to get the EVM tests running in EOS VM OC. Using OC improves the performance of test runs but also means the tests are running in the same environment we nominally expect it to be run in production on EOS: via OC. (Clearly contract unit tests aren't intended to exercise correctness of Leap's runtime environment, but it's still nice to see the tests run properly this way.)

Enabling tests to run via EOS VM OC consists of two main changes,
* Move libtester to 5.0 since we need AntelopeIO/leap#1843 to disable OC's subjective limits for the massive consensus-testing build of the EVM contract. Unfortunately, actually, we need a post-5.0.0 since this disablement wasn't entirely plumbed through until AntelopeIO/leap#2055
* We need a larger OC cache than libtester's default (8MB) for the massive consensus-testing build of the EVM contract. This configuration change is performed locally here in the `eosio_system_tester` instead of changing libtester's default, but this modification is not without some significant annoyance.

See inline comments for some additional caveats. 

PR also makes some other minor bumps to CI components, like using ubuntu22 now.
