### PR TITLE
only use EOS VM OC for contract test on Linux

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,6 +53,6 @@ add_eosio_test_executable( unit_test
     ${CMAKE_SOURCE_DIR}/external/ethash/lib/ethash/primes.c
 )
 
-add_test(NAME consensus_tests COMMAND unit_test --report_level=detailed --color_output --run_test=evm_runtime_tests -- --eos-vm-oc)
+add_test(NAME consensus_tests COMMAND unit_test --report_level=detailed --color_output --run_test=evm_runtime_tests -- $<$<PLATFORM_ID:Linux>:--eos-vm-oc>)
 
-add_test(NAME unit_tests COMMAND unit_test --report_level=detailed --color_output --run_test=!evm_runtime_tests -- --eos-vm-oc)
+add_test(NAME unit_tests COMMAND unit_test --report_level=detailed --color_output --run_test=!evm_runtime_tests -- $<$<PLATFORM_ID:Linux>:--eos-vm-oc>)


### PR DESCRIPTION
EOS VM OC isn't supported on macOS, etc, so we shouldn't use it except on Linux. A better solution would be for libtester's cmake to expose support of OC to us, but will work for now.