### PR TITLE
`cmake_minimum_required()` before `project()` to avoid cmake warning

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(evm_runtime_tests)
 cmake_minimum_required(VERSION 3.12)
+project(evm_runtime_tests)
 
 find_package(eosio)
 


### PR DESCRIPTION
fixes a warning on cmake
```
CMake Warning (dev) at CMakeLists.txt:1 (project):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
This warning is for project developers.  Use -Wno-dev to suppress it.

```