### PR TITLE
configurable ingress gas limit

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -68,7 +68,7 @@ jobs:
           owner: AntelopeIO
           repo: spring
           file: 'antelope-spring-dev.*ubuntu22\.04_amd64.deb'
-          target: 'main'
+          target: '1'
           prereleases: false
           artifact-name: antelope-spring-dev-ubuntu22-amd64
           container-package: antelope-spring-experimental-binaries

--- a/include/evm_runtime/config_wrapper.hpp
+++ b/include/evm_runtime/config_wrapper.hpp
@@ -57,6 +57,9 @@ struct config_wrapper {
     eosio::symbol get_token_symbol() const;
     uint64_t get_minimum_natively_representable() const;
 
+    void set_ingress_gas_limit(uint64_t gas_limit);
+    uint64_t get_ingress_gas_limit() const;
+
 private:
     void set_queue_front_block(uint32_t block_num);
     

--- a/include/evm_runtime/evm_contract.hpp
+++ b/include/evm_runtime/evm_contract.hpp
@@ -88,7 +88,7 @@ public:
    [[eosio::action]] void updtgasparam(eosio::asset ram_price_mb, uint64_t gas_price);
    [[eosio::action]] void setgasparam(uint64_t gas_txnewaccount, uint64_t gas_newaccount, uint64_t gas_txcreate, uint64_t gas_codedeposit, uint64_t gas_sset);
 
-   [[eosio::action]] void setgaslimit(std::optional<uint64_t> ingress_gas_limit);
+   [[eosio::action]] void setgaslimit(uint64_t ingress_gas_limit);
 
    // Events
    [[eosio::action]] void evmtx(eosio::ignore<evm_runtime::evmtx_type> event){

--- a/include/evm_runtime/evm_contract.hpp
+++ b/include/evm_runtime/evm_contract.hpp
@@ -88,6 +88,8 @@ public:
    [[eosio::action]] void updtgasparam(eosio::asset ram_price_mb, uint64_t gas_price);
    [[eosio::action]] void setgasparam(uint64_t gas_txnewaccount, uint64_t gas_newaccount, uint64_t gas_txcreate, uint64_t gas_codedeposit, uint64_t gas_sset);
 
+   [[eosio::action]] void setgaslimit(std::optional<uint64_t> ingress_gas_limit);
+
    // Events
    [[eosio::action]] void evmtx(eosio::ignore<evm_runtime::evmtx_type> event){
       eosio::check(get_sender() == get_self(), "forbidden to call");

--- a/include/evm_runtime/tables.hpp
+++ b/include/evm_runtime/tables.hpp
@@ -346,7 +346,7 @@ struct [[eosio::table]] [[eosio::contract("evm_contract")]] config
     binary_extension<consensus_parameter_type> consensus_parameter;
     binary_extension<eosio::name> token_contract; // <- default(unset) means eosio.token
     binary_extension<uint32_t> queue_front_block;
-    binary_extension<uint64_t> ingress_gas_limit = 21000;
+    binary_extension<uint64_t> ingress_gas_limit;
 
     EOSLIB_SERIALIZE(config, (version)(chainid)(genesis_time)(ingress_bridge_fee)(gas_price)(miner_cut)(status)(evm_version)(consensus_parameter)(token_contract)(queue_front_block)(ingress_gas_limit));
 };

--- a/include/evm_runtime/tables.hpp
+++ b/include/evm_runtime/tables.hpp
@@ -346,8 +346,9 @@ struct [[eosio::table]] [[eosio::contract("evm_contract")]] config
     binary_extension<consensus_parameter_type> consensus_parameter;
     binary_extension<eosio::name> token_contract; // <- default(unset) means eosio.token
     binary_extension<uint32_t> queue_front_block;
+    binary_extension<uint64_t> ingress_gas_limit = 21000;
 
-    EOSLIB_SERIALIZE(config, (version)(chainid)(genesis_time)(ingress_bridge_fee)(gas_price)(miner_cut)(status)(evm_version)(consensus_parameter)(token_contract)(queue_front_block));
+    EOSLIB_SERIALIZE(config, (version)(chainid)(genesis_time)(ingress_bridge_fee)(gas_price)(miner_cut)(status)(evm_version)(consensus_parameter)(token_contract)(queue_front_block)(ingress_gas_limit));
 };
 
 struct [[eosio::table]] [[eosio::contract("evm_contract")]] price_queue

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -660,7 +660,7 @@ void evm_contract::handle_evm_transfer(eosio::asset quantity, const std::string&
     value *= intx::uint256(_config->get_minimum_natively_representable());
 
     auto calculate_gas_limit = [&](const evmc::address& destination) -> int64_t {
-        int64_t gas_limit = 21000;
+        int64_t gas_limit = _config->get_ingress_gas_limit();
 
         account_table accounts(get_self(), get_self().value);
         auto inx = accounts.get_index<"by.address"_n>();
@@ -897,6 +897,12 @@ void evm_contract::setgasparam(uint64_t gas_txnewaccount,
                                 gas_txcreate,
                                 gas_codedeposit,
                                 gas_sset);
+}
+
+void evm_contract::setgaslimit(std::optional<uint64_t> ingress_gas_limit) {
+    if (ingress_gas_limit.has_value()) {
+        _config->set_ingress_gas_limit(*ingress_gas_limit);
+    }
 }
 
 } //evm_runtime

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -899,10 +899,8 @@ void evm_contract::setgasparam(uint64_t gas_txnewaccount,
                                 gas_sset);
 }
 
-void evm_contract::setgaslimit(std::optional<uint64_t> ingress_gas_limit) {
-    if (ingress_gas_limit.has_value()) {
-        _config->set_ingress_gas_limit(*ingress_gas_limit);
-    }
+void evm_contract::setgaslimit(uint64_t ingress_gas_limit) {
+    _config->set_ingress_gas_limit(ingress_gas_limit);
 }
 
 } //evm_runtime

--- a/src/config_wrapper.cpp
+++ b/src/config_wrapper.cpp
@@ -347,4 +347,13 @@ bool config_wrapper::check_gas_overflow(uint64_t gas_txcreate, uint64_t gas_code
     return true;
 }
 
+void config_wrapper::set_ingress_gas_limit(uint64_t gas_limit) {
+    _cached_config.ingress_gas_limit = gas_limit;
+    set_dirty();
+}
+
+uint64_t config_wrapper::get_ingress_gas_limit() const {
+    return *_cached_config.ingress_gas_limit;
+}
+
 } //namespace evm_runtime

--- a/src/config_wrapper.cpp
+++ b/src/config_wrapper.cpp
@@ -21,6 +21,9 @@ config_wrapper::config_wrapper(eosio::name self) : _self(self), _config(self, se
     if (!_cached_config.queue_front_block.has_value()) {
         _cached_config.queue_front_block = 0;
     }
+    if (!_cached_config.ingress_gas_limit.has_value()) {
+        _cached_config.ingress_gas_limit = 21000;
+    }
 }
 
 config_wrapper::~config_wrapper() {


### PR DESCRIPTION
Resolves #776 

command example:
```
./cleos push action eosio.evm setgaslimit '["30000"]' -p  eosio.evm
```
